### PR TITLE
appveyor.yml を導入

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+configuration:
+  - Release
+  - Debug
+
+platform:
+  - Win32
+  - x64
+
+build_script:
+- cmd: >-
+    echo PLATFORM        %PLATFORM%
+
+    echo CONFIGURATION   %CONFIGURATION%


### PR DESCRIPTION
sandbox に appveyor.yml を導入します。

appveyor.yml で build_script の cmd で先頭に @ をつけるとうまく動かないようです。

例: `@echo PLATFORM        %PLATFORM%`